### PR TITLE
Removing redundant print of current repo

### DIFF
--- a/rules/git/git_cached_repository.bzl
+++ b/rules/git/git_cached_repository.bzl
@@ -94,7 +94,7 @@ def _should_clone_repo(repo_ctx, repo_local_cache_path):
             "get-url",
             "origin",
         ]
-        st = repo_ctx.execute(args, quiet = False)
+        st = repo_ctx.execute(args, quiet = True)
         if st.return_code == 0:
             stripped_url = st.stdout.strip().replace("\n", "")
 


### PR DESCRIPTION
Noticed that while the rule executes the `git -C ~/.git-cache/xxx/.git remote get-url origin` it prints the output the the regular stdout. I find that redundant.