### PR TITLE
[src] Remove stale git index.lock file from a cached repository if exists during a git cached rule execution

### DIFF
--- a/rules/git/git_cached_repository.bzl
+++ b/rules/git/git_cached_repository.bzl
@@ -120,6 +120,12 @@ def _create_local_cache_folder_for_repo(repo_ctx, repo_local_cache_path):
     args = ["mkdir", "-p", repo_local_cache_path]
     repo_ctx.execute(args, quiet = False)
 
+def _remove_git_lockfile_if_exists(repo_ctx, repo_local_cache_path):
+    lock_index_path = repo_local_cache_path + "/.git/index.lock"
+    if repo_ctx.path(lock_index_path).exists:
+        _log(repo_ctx, "Clearing git index.lock file. path: {}".format(lock_index_path))
+        repo_ctx.delete(lock_index_path)
+
 def _fresh_clone(repo_ctx, repo_local_cache_path):
     """ Clone a repository to a folder specified by the 'repo_local_cache_path' argument,
         clear previous directory if existed before
@@ -216,6 +222,7 @@ def _git_cached_repository_implementation(repo_ctx):
     if _should_clone_repo(repo_ctx, repo_local_cache_path):
         _fresh_clone(repo_ctx, repo_local_cache_path)
     else:
+        _remove_git_lockfile_if_exists(repo_ctx, repo_local_cache_path)
         _checkout_or_fetch(repo_ctx, repo_local_cache_path)
 
 git_cached_repository = repository_rule(

--- a/testing/e2e/git_rules_testkit.sh
+++ b/testing/e2e/git_rules_testkit.sh
@@ -89,7 +89,7 @@ EOF
 
 function create_sh_binary_ref_small_repo() {
   target_name=quote_reader
-  target_label="quotes:${target_name}"
+  target_label="//quotes:${target_name}"
 
   mkdir -p quotes
   cat >quotes/BUILD.bazel <<EOF

--- a/testing/e2e/repos_loader.sh
+++ b/testing/e2e/repos_loader.sh
@@ -15,7 +15,7 @@ function prepare_test_repositories() {
     rm -rf ${REPOS_DIR}
   fi
 
-  if [[ -d ${repos_dir} ]]; then
+  if [[ -d ${REPOS_DIR} ]]; then
     log_info "Repositories folder is already initialized, skipping"
   fi
 


### PR DESCRIPTION
[src] Added test coverage for index.lock file removal
[fix] Missing backslashes on sh_binary target label creation
[fix] Typo in repo_dir var name used for validation when preparing test repositories