### PR TITLE
[src] Re-clone (init & fetch) git index if existing index is invalid and/or missing remote origin

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -12,7 +12,7 @@ run-tests-dockerized: ## Run tests suites dockerized
         -c 'cd /home/wix_build_tools; make run-tests-ci'
 
 # To use on version 3.0.0 of Docker for mac - disable use gRPC FUSE for file sharing in Preferences -> Experimental Features.
-# Debug within the container by using:
+# Debug within the container by using: (run from wix_build_tools root folder)
 #  - docker run -it -v $(PWD):/home/wix_build_tools --entrypoint /bin/sh l.gcr.io/google/bazel:3.5.0
 
 .PHONY: help

--- a/rules/git/git_cached_repository.bzl
+++ b/rules/git/git_cached_repository.bzl
@@ -73,11 +73,9 @@ def _get_local_cache_repo_path(repo_ctx):
     return "{}/{}".format(repo_ctx.attr.cache_directory, repo_ctx.name)
 
 def _should_clone_repo(repo_ctx, repo_local_cache_path):
-    index_missing = not _is_git_index_exists(repo_ctx, repo_local_cache_path)
-    origin_and_repo_url_mismatch = not _is_origin_match_repo_url(repo_ctx, repo_local_cache_path)
-    index_invalid = not _is_valid_git_index(repo_ctx, repo_local_cache_path)
-
-    return index_missing or origin_and_repo_url_mismatch or index_invalid
+    return not _is_git_index_exists(repo_ctx, repo_local_cache_path) or \
+           not _is_origin_match_repo_url(repo_ctx, repo_local_cache_path) or \
+           not _is_valid_git_index(repo_ctx, repo_local_cache_path)
 
 def _is_git_index_exists(repo_ctx, repo_local_cache_path):
     """ Checks that a local git index exists at the repository cache path

--- a/testing/e2e/git_rules_utils.sh
+++ b/testing/e2e/git_rules_utils.sh
@@ -33,3 +33,18 @@ function delete_git_cached_directory() {
     rm -rf "${HOME}/.git-cache"
   fi
 }
+
+function git_init_fresh_index() {
+  cache_dir=$1
+  if [[ (! -z ${cache_dir}) && (! -d ${cache_dir}) ]]; then
+    mkdir -p "${cache_dir}"
+  fi
+
+  /usr/bin/git init "${cache_dir}" >>${TEST_log}
+}
+
+function git_remote_add_origin() {
+  cache_dir=$1
+  origin=$2
+  /usr/bin/git -C "${cache_dir}" remote add origin "${origin}" >>${TEST_log}
+}


### PR DESCRIPTION
[src] Simplify git URL vs. repository rule remote_url verification to prevent misplaced git URL on its cache repo directory
[src] Added a test that verifies force clone when remote origin is missing
[src] Added a test that verifies force clone on invalid git index
[src] Added two new rules utils: git init & git remote add origin